### PR TITLE
V2.46

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ This configures your org to essentially allow applications to run that call out 
 10/xx/20 -  Eric Smith -    Version 2.46 -  
             Updates:        Added new Output Parameter for the # of Selected Records 
                             (this can be used for conditional visibility on the same screen as the datatable)  
-                            New Required? Parameter - Requires the user to select at least 1 row to proceed
-                            New optional Table Header with Table Icon and Table Label Parameters
+                            New Required? Parameter - Requires the user to select at least 1 row to proceed  
+                            New Selected Record Output Parameter - Returns an SObject record if just a single record is selected  
+                            New optional Table Header with Table Icon and Table Label Parameters  
                             Switched DualListbox to the fbc version  
                             Added spinners while sorting & filtering data  
                             Allow case insensitive field API names  

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This configures your org to essentially allow applications to run that call out 
 10/xx/20 -  Eric Smith -    Version 2.46 -  
             Updates:        Switched DualListbox to the fbc version
                             Added spinners while sorting & filtering data
+                            Allow case insensitive field API names
               
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This configures your org to essentially allow applications to run that call out 
 ---
 ## Release Notes
 10/xx/20 -  Eric Smith -    Version 2.46 -  
-            Updates:        Switched DualListbox to the fbc version
+            Updates:        Added new Output Parameter for the # of Selected Records
+                            Switched DualListbox to the fbc version
                             Added spinners while sorting & filtering data
                             Allow case insensitive field API names
               

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This configures your org to essentially allow applications to run that call out 
                             Switched DualListbox to the fbc version  
                             Added spinners while sorting & filtering data  
                             Allow case insensitive field API names  
+                            Allow custom field API names w/o the __c suffix  
   
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This configures your org to essentially allow applications to run that call out 
 ## Release Notes
 10/xx/20 -  Eric Smith -    Version 2.46 -  
             Updates:        Switched DualListbox to the fbc version
+                            Added spinners while sorting & filtering data
               
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ This configures your org to essentially allow applications to run that call out 
 ---
 ## Release Notes
 10/xx/20 -  Eric Smith -    Version 2.46 -  
-            Updates:        Added new Output Parameter for the # of Selected Records
-                            Switched DualListbox to the fbc version
-                            Added spinners while sorting & filtering data
-                            Allow case insensitive field API names
-              
+            Updates:        Added new Output Parameter for the # of Selected Records  
+                            Switched DualListbox to the fbc version  
+                            Added spinners while sorting & filtering data  
+                            Allow case insensitive field API names  
+  
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)
   

--- a/README.md
+++ b/README.md
@@ -53,15 +53,16 @@ This configures your org to essentially allow applications to run that call out 
 ## Release Notes
 10/xx/20 -  Eric Smith -    Version 2.46 -  
             Updates:        Added new Output Parameter for the # of Selected Records 
-                            (this can be used for conditional visibility on the same screen as the datatable)  
+                            (this can be used for conditional visibility on the same screen as the datatable)   
+                            New Selected Record Output Parameter - Returns an SObject record if just a single record is selected 
                             New Required? Parameter - Requires the user to select at least 1 row to proceed  
-                            New Selected Record Output Parameter - Returns an SObject record if just a single record is selected  
                             New optional Table Header with Table Icon and Table Label Parameters  
                             Switched DualListbox to the fbc version  
                             Added spinners while sorting & filtering data  
                             Allow case insensitive field API names  
                             Allow custom field API names w/o the __c suffix  
             Bug Fixes:      Display Picklist Labels instead of API Names for Picklist and Multipicklist fields  
+                            Added a Clear Selection button for tables with just a single record
   
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This configures your org to essentially allow applications to run that call out 
 
 ---
 ## Release Notes
-10/xx/20 -  Eric Smith -    Version 2.46 -  
+10/07/20 -  Eric Smith -    Version 2.46 -  
             Updates:        Added new Output Parameter for the # of Selected Records 
                             (this can be used for conditional visibility on the same screen as the datatable)   
                             New Selected Record Output Parameter - Returns an SObject record if just a single record is selected 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ This configures your org to essentially allow applications to run that call out 
 ---
 ## Release Notes
 10/xx/20 -  Eric Smith -    Version 2.46 -  
-            Updates:        Added new Output Parameter for the # of Selected Records  
+            Updates:        Added new Output Parameter for the # of Selected Records 
+                            (this can be used for conditional visibility on the same screen as the datatable)  
                             Switched DualListbox to the fbc version  
                             Added spinners while sorting & filtering data  
                             Allow case insensitive field API names  

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This configures your org to essentially allow applications to run that call out 
 10/xx/20 -  Eric Smith -    Version 2.46 -  
             Updates:        Added new Output Parameter for the # of Selected Records 
                             (this can be used for conditional visibility on the same screen as the datatable)  
+                            New Required? Parameter - Requires the user to select at least 1 row to proceed
+                            New optional Table Header with Table Icon and Table Label Parameters
                             Switched DualListbox to the fbc version  
                             Added spinners while sorting & filtering data  
                             Allow case insensitive field API names  

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This configures your org to essentially allow applications to run that call out 
                             Added spinners while sorting & filtering data  
                             Allow case insensitive field API names  
                             Allow custom field API names w/o the __c suffix  
+            Bug Fixes:      Display Picklist Labels instead of API Names for Picklist and Multipicklist fields  
   
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ This configures your org to essentially allow applications to run that call out 
 
 ---
 ## Release Notes
+10/xx/20 -  Eric Smith -    Version 2.46 -  
+            Updates:        Switched DualListbox to the fbc version
+              
 09/22/20 -  Eric Smith -    Version 2.45 -  
             Bug Fix:        Fixed inability to edit some field types (introduced by v2.44)
   

--- a/force-app/main/default/classes/SObjectController2.cls
+++ b/force-app/main/default/classes/SObjectController2.cls
@@ -16,6 +16,8 @@
  *              of the Name fields in the corresponding records. Return the
  *              records that now include both the Id and Name for each lookup.
  * 
+ * 10/xx/20 -   Eric Smith -    Version 2.46    Issue error if no field names are given
+ * 
  * 09/22/20 -   Eric Smith -    Version 2.45    Set type as Richtext for Text Formula Fields
  * 
  * 09/01/20 -   Eric Smith -    Version 2.43    Update Percent Field Handling and set Formula Fields to be Non-Editable 
@@ -67,7 +69,7 @@ public with sharing class SObjectController2 {
         if (records.isEmpty()) {
             // throw new MyApexException ('The datatable record collection is empty');
             List<String> emptyList = new List<String>();
-            curRR.dtableColumnFieldDescriptorString = '{"label":"Empty Table", "fieldName":"Id", "type":"text"}';
+            curRR.dtableColumnFieldDescriptorString = '{"label":"Empty Table, Fields ['+fieldNames+']", "fieldName":"Id", "type":"text"}';
             curRR.lookupFieldData = '{}';
             curRR.lookupFieldList = emptyList;
             curRR.percentFieldList = emptyList;
@@ -90,7 +92,10 @@ public with sharing class SObjectController2 {
 
     @AuraEnabled
     public static ReturnResults getColumnData(ReturnResults curRR, String fields, String objName) {
-        
+
+        if (fields == '') 
+            throw new MyApexException('You must specify at least one field API name from the object ' + objName);
+
         SObjectType sobjType = ((SObject)(Type.forName('Schema.'+objName).newInstance())).getSObjectType();
         DescribeSObjectResult objDescribe = sobjType.getDescribe();
 
@@ -110,7 +115,7 @@ public with sharing class SObjectController2 {
             Map<String, Schema.SObjectField> fieldMap = objDescribe.fields.getMap();
             Schema.SObjectField fieldItem = fieldMap.get(fieldName);
             if (fieldItem == null) 
-                throw new MyApexException('could not find the field: ' + fieldName + ' on the object ' + objName);
+                throw new MyApexException('Could not find the field: ' + fieldName + ' on the object ' + objName);
             Schema.DescribeFieldResult dfr = fieldItem.getDescribe();
             curFieldDescribes.add(dfr);
 

--- a/force-app/main/default/classes/SObjectController2.cls
+++ b/force-app/main/default/classes/SObjectController2.cls
@@ -17,6 +17,8 @@
  *              records that now include both the Id and Name for each lookup.
  * 
  * 10/xx/20 -   Eric Smith -    Version 2.46    Issue error if no field names are given
+ *                                              Allow case insensitive field names
+ *                                              Allow custom field API names w/o the __c suffix
  * 
  * 09/22/20 -   Eric Smith -    Version 2.45    Set type as Richtext for Text Formula Fields
  * 
@@ -114,8 +116,14 @@ public with sharing class SObjectController2 {
 
             Map<String, Schema.SObjectField> fieldMap = objDescribe.fields.getMap();
             Schema.SObjectField fieldItem = fieldMap.get(fieldName);
-            if (fieldItem == null) 
-                throw new MyApexException('Could not find the field: ' + fieldName + ' on the object ' + objName);
+            if (fieldItem == null) {
+                Schema.SObjectField fieldItem2 = fieldMap.get(fieldName + '__c');  // Allow for user to forget to add __c for custom fields
+                if (fieldItem2 == null) {
+                    throw new MyApexException('Could not find the field: ' + fieldName + ' on the object ' + objName);
+                } else {
+                    fieldItem = fieldItem2;
+                }
+            }
             Schema.DescribeFieldResult dfr = fieldItem.getDescribe();
             curFieldDescribes.add(dfr);
 

--- a/force-app/main/default/classes/SObjectController2.cls
+++ b/force-app/main/default/classes/SObjectController2.cls
@@ -121,7 +121,7 @@ public with sharing class SObjectController2 {
 
             datatableColumnFieldDescriptor = datatableColumnFieldDescriptor 
                 + ',{"label" : "' + dfr.getLabel() 
-                + '", "fieldName" : "' + fieldName 
+                + '", "fieldName" : "' + dfr.getName()      // pass back correct API name if user did not pass in correct case (Name vs name)
                 + '", "type" : "' + convertType(dfr.getType().name(), dfr.isCalculated()) 
                 + '", "scale" : "' + dfr.getScale() 
                 + '"}';

--- a/force-app/main/default/classes/SObjectController2.cls
+++ b/force-app/main/default/classes/SObjectController2.cls
@@ -19,6 +19,7 @@
  * 10/xx/20 -   Eric Smith -    Version 2.46    Issue error if no field names are given
  *                                              Allow case insensitive field names
  *                                              Allow custom field API names w/o the __c suffix
+ *                                              Get and Return which fields are picklist fields along with Value & Label
  * 
  * 09/22/20 -   Eric Smith -    Version 2.45    Set type as Richtext for Text Formula Fields
  * 
@@ -55,9 +56,11 @@ public with sharing class SObjectController2 {
         List<String> lookupFieldList;
         Map<String, Map<Id, SObject>> dataMap;
         Map<String, String> objNameFieldMap;
+        Map<String, Map<String,String>> picklistFieldMap;   // Field API Name, <Picklist Value, Picklist Label>
         List<String> percentFieldList;
         List<String> noEditFieldList;
         list<String> timeFieldList;
+        list<String> picklistFieldList;
         String objectName;
         String objectLinkField;
         String timezoneOffset;
@@ -77,6 +80,7 @@ public with sharing class SObjectController2 {
             curRR.percentFieldList = emptyList;
             curRR.noEditFieldList = emptyList;
             curRR.timeFieldList = emptyList;
+            curRR.picklistFieldList = emptyList;
             curRR.rowData = records;
             curRR.objectName = 'EmptyCollection';
             curRR.objectLinkField = '';
@@ -109,6 +113,8 @@ public with sharing class SObjectController2 {
         List<String> percentFields = new List<String>();
         List<String> noEditFields = new List<String>();
         List<String> timeFields = new List<String>();
+        List<String> picklistFields = new List<String>();
+        Map<String, Map<String, String>> picklistFieldLabels = new Map<String, Map<String, String>>();
         String objectLinkField = getNameUniqueField(objName);   // Name (link) Field for the Datatable SObject
         System.debug('*** OBJ/LINK' + objname + '/' + objectLinkField);
 
@@ -146,12 +152,12 @@ public with sharing class SObjectController2 {
                     percentFields.add(fieldName);
                 }
                 when 'TEXTAREA' {
-                    if (!dfr.isSortable() && !noEditFields.contains(fieldname)) {
+                    if (!dfr.isSortable() && !noEditFields.contains(fieldName)) {
                         noEditFields.add(fieldName); // Long Text Area and Rich Text Area   
                     }                   
                 }
-                when 'ENCRYPTEDSTRING', 'PICKLIST', 'MULTIPICKLIST' {
-                    if (!noEditFields.contains(fieldname)) {
+                when 'ENCRYPTEDSTRING' {
+                    if (!noEditFields.contains(fieldName)) {
                         noEditFields.add(fieldName);
                     }
                 }
@@ -160,6 +166,17 @@ public with sharing class SObjectController2 {
                 }
                 when 'TIME' {
                     timeFields.add(fieldName);
+                }
+                when 'PICKLIST', 'MULTIPICKLIST' {
+                    picklistFields.add(dfr.getName());
+                    if (!noEditFields.contains(fieldName)) {
+                        noEditFields.add(fieldName);
+                    }
+                    Map<String, String> valueLabelPair = new Map<String, String>();
+                    for(Schema.PicklistEntry ple : dfr.getPicklistValues()) {
+                        valueLabelPair.put(ple.getValue(), ple.getLabel());
+                    }
+                    picklistFieldLabels.put(dfr.getName(), valueLabelPair);
                 }
                 when else {
                 }
@@ -173,6 +190,8 @@ public with sharing class SObjectController2 {
         curRR.percentFieldList = percentFields;
         curRR.noEditFieldList = noEditFields;
         curRR.timeFieldList = timeFields;
+        curRR.picklistFieldList = picklistFields;
+        curRR.picklistFieldMap = picklistFieldLabels;
         curRR.objectLinkField = objectLinkField;
         return curRR;
     }

--- a/force-app/main/default/flows/Datatable_Configuration_Helper.flow-meta.xml
+++ b/force-app/main/default/flows/Datatable_Configuration_Helper.flow-meta.xml
@@ -280,7 +280,7 @@
         </fields>
         <fields>
             <name>SelectFields</name>
-            <extensionName>c:dualListBox2</extensionName>
+            <extensionName>c:fbc_dualListBox2</extensionName>
             <fieldType>ComponentInstance</fieldType>
             <inputParameters>
                 <name>allOptionsStringFormat</name>
@@ -295,27 +295,21 @@
                 </value>
             </inputParameters>
             <inputParameters>
+                <name>required</name>
+                <value>
+                    <booleanValue>true</booleanValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
                 <name>allOptionsFieldDescriptorList</name>
                 <value>
                     <elementReference>apexColFieldDescriptors</elementReference>
                 </value>
             </inputParameters>
             <inputParameters>
-                <name>min</name>
+                <name>useWhichObjectKeyForSort</name>
                 <value>
-                    <numberValue>1.0</numberValue>
-                </value>
-            </inputParameters>
-            <inputParameters>
-                <name>max</name>
-                <value>
-                    <numberValue>20.0</numberValue>
-                </value>
-            </inputParameters>
-            <inputParameters>
-                <name>size</name>
-                <value>
-                    <numberValue>10.0</numberValue>
+                    <stringValue>label</stringValue>
                 </value>
             </inputParameters>
             <inputParameters>
@@ -337,15 +331,21 @@
                 </value>
             </inputParameters>
             <inputParameters>
-                <name>required</name>
+                <name>min</name>
                 <value>
-                    <booleanValue>true</booleanValue>
+                    <numberValue>1.0</numberValue>
                 </value>
             </inputParameters>
             <inputParameters>
-                <name>useWhichObjectKeyForSort</name>
+                <name>max</name>
                 <value>
-                    <stringValue>label</stringValue>
+                    <numberValue>20.0</numberValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>size</name>
+                <value>
+                    <numberValue>10.0</numberValue>
                 </value>
             </inputParameters>
             <isRequired>true</isRequired>

--- a/force-app/main/default/lwc/datatableV2/datatableV2.html
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.html
@@ -11,7 +11,7 @@ Additional components packaged with this LWC:
                     Apex Classes:               SObjectController2 
                                                 SObjectController2Test
 
-VERSION:            2.45
+VERSION:            2.46
 
 RELEASE NOTES:      https://github.com/ericrsmith35/DatatableV2/blob/master/README.md
 

--- a/force-app/main/default/lwc/datatableV2/datatableV2.html
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.html
@@ -94,32 +94,49 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVE
         </template>
 
         <!-- DATATABLE -->
-        <div style={tableHeight} class={borderClass}>
-            <c-rich-datatable
-                data={mydata}
-                columns={columns}
-                key-field={keyField}
-                sorted-by={sortedBy}
-                sorted-direction={sortedDirection}
-                max-row-selection={maxRowSelection}
-                selected-rows={selectedRows}
-                hide-checkbox-column={hideCheckboxColumn}
-                suppress-bottom-bar={suppressBottomBar}
-                onsort={updateColumnSorting}
-                oncellchange={handleCellChange}
-                onsave={handleSave}
-                oncancel={cancelChanges}
-                onheaderaction={handleHeaderAction}
-                onrowselection={handleRowSelection}
-                onrowaction={handleRowAction}
-                onresize={handleResize}
-            >
-            </c-rich-datatable>
-        </div>
-        <div if:true={isWorking}>
-            <lightning-spinner
-                alternative-text="Working..." variant="brand">
-            </lightning-spinner>
+        <div class={formElementClass}>
+            <label class="slds-form-element__label" for="datatable">
+                <div class="slds-media slds-media_center slds-media_small">
+                    <abbr class="slds-required" title="required">{requiredSymbol}</abbr>
+                    <div class="slds-media__figure">
+                        <template if:true={hasIcon}>
+                            <lightning-icon icon-name="standard:account" alternative-text="Datatable Icon" title="Icon" size="small"></lightning-icon>
+                        </template>
+                    </div>
+                    <div class="slds-media__body">
+                        <lightning-formatted-rich-text value={formattedTableLabel}></lightning-formatted-rich-text>
+                    </div>
+                </div>
+            </label>
+
+            <div style={tableHeight} class={borderClass} id="datatable">
+                <c-rich-datatable
+                    data={mydata}
+                    columns={columns}
+                    key-field={keyField}
+                    sorted-by={sortedBy}
+                    sorted-direction={sortedDirection}
+                    max-row-selection={maxRowSelection}
+                    selected-rows={selectedRows}
+                    hide-checkbox-column={hideCheckboxColumn}
+                    suppress-bottom-bar={suppressBottomBar}
+                    onsort={updateColumnSorting}
+                    oncellchange={handleCellChange}
+                    onsave={handleSave}
+                    oncancel={cancelChanges}
+                    onheaderaction={handleHeaderAction}
+                    onrowselection={handleRowSelection}
+                    onrowaction={handleRowAction}
+                    onresize={handleResize}
+                >
+                </c-rich-datatable>
+            </div>
+            <div if:true={isWorking}>
+                <lightning-spinner
+                    alternative-text="Working..." variant="brand">
+                </lightning-spinner>
+            </div>
+
         </div>
 
         <!-- Special parameter display for Configuration Mode -->

--- a/force-app/main/default/lwc/datatableV2/datatableV2.html
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.html
@@ -116,6 +116,11 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVE
             >
             </c-rich-datatable>
         </div>
+        <div if:true={isWorking}>
+            <lightning-spinner
+                alternative-text="Working..." variant="brand">
+            </lightning-spinner>
+        </div>
 
         <!-- Special parameter display for Configuration Mode -->
         <template if:true={isConfigMode}>

--- a/force-app/main/default/lwc/datatableV2/datatableV2.html
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.html
@@ -130,6 +130,9 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVE
                     onresize={handleResize}
                 >
                 </c-rich-datatable>
+                <div if:true={showClearButton} class="slds-m-top_x-small">
+                    <lightning-button variant="brand-outline" label="Clear Selection" icon-name="utility:clear" onclick={handleClearSelection}></lightning-button>
+                </div>
             </div>
             <div if:true={isWorking}>
                 <lightning-spinner

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -65,6 +65,7 @@ export default class DatatableV2 extends LightningElement {
     @api suppressNameFieldLink = false;
     @api tableHeight;
     @api outputSelectedRows = [];
+    @api outputSelectedRow;
     @api outputEditedRows = [];
     @api tableBorder;
     @api tableIcon;
@@ -379,7 +380,7 @@ export default class DatatableV2 extends LightningElement {
 
         // Handle pre-selected records
         this.outputSelectedRows = this.preSelectedRows;
-        this.updateNumberOfRowsSelected(this.outputSelectedRows.length);
+        this.updateNumberOfRowsSelected(this.outputSelectedRows);
         if (this.isUserDefinedObject) {
             this.outputSelectedRowsString = JSON.stringify(this.outputSelectedRows);                                        //JSON Version
             this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRowsString', this.outputSelectedRowsString));    //JSON Version
@@ -943,7 +944,7 @@ export default class DatatableV2 extends LightningElement {
         // Only used with row selection
         // Update values to be passed back to the Flow
         let selectedRows = event.detail.selectedRows;
-        this.updateNumberOfRowsSelected(selectedRows.length);
+        this.updateNumberOfRowsSelected(selectedRows);
         this.setIsInvalidFlag(false);
         if(this.isRequired && this.numberOfRowsSelected == 0) {
             this.setIsInvalidFlag(true);
@@ -963,10 +964,13 @@ export default class DatatableV2 extends LightningElement {
         console.log('outputSelectedRows',this.outputSelectedRows);
     }
 
-    updateNumberOfRowsSelected(numberOfRows) {
+    updateNumberOfRowsSelected(selectedRows) {
         // Handle updating output attribute for the number of selected rows
-        this.numberOfRowsSelected = numberOfRows;
+        this.numberOfRowsSelected = selectedRows.length;
         this.dispatchEvent(new FlowAttributeChangeEvent('numberOfRowsSelected', this.numberOfRowsSelected));
+        // Return an SObject Record if just a single row is selected
+        this.outputSelectedRow = (this.numberOfRowsSelected == 1) ? selectedRows[0] : null;
+        this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRow', this.outputSelectedRow));
     }
 
     updateColumnSorting(event) {

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -27,7 +27,7 @@
  *  
  **/
 
- const VERSION_NUMBER = 2.46;
+const VERSION_NUMBER = 2.46;
 
 import { LightningElement, api, track, wire } from 'lwc';
 import getReturnResults from '@salesforce/apex/SObjectController2.getReturnResults';

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -57,6 +57,7 @@ export default class DatatableV2 extends LightningElement {
     @api maxNumberOfRows;
     @api preSelectedRows = [];
     @api numberOfRowsSelected = 0;
+    @api isRequired;
     @api isConfigMode;
     @api hideCheckboxColumn;
     @api singleRowSelection;
@@ -66,6 +67,8 @@ export default class DatatableV2 extends LightningElement {
     @api outputSelectedRows = [];
     @api outputEditedRows = [];
     @api tableBorder;
+    @api tableIcon;
+    @api tableLabel;
 
     // JSON Version Attributes (User Defined Object)
     @api isUserDefinedObject = false;
@@ -145,6 +148,7 @@ export default class DatatableV2 extends LightningElement {
     @api attribCount = 0;
     @api recordData = [];
     @api timezoneOffset = 0;
+    @track isInvalid = false;
     @track isWorking = false;
     @track showSpinner = true;
     @track borderClass;
@@ -154,6 +158,22 @@ export default class DatatableV2 extends LightningElement {
     @track columnWidthParameter;
     @track columnEditParameter;
     @track columnFilterParameter;
+
+    get formElementClass() {
+        return this.isInvalid ? 'slds-form-element slds-has-error' : 'slds-form-element';
+    }
+
+    get requiredSymbol() {
+        return this.isRequired ? '*' : '';
+    }
+
+    get hasIcon() {
+        return (this.tableIcon && this.tableIcon.length > 0);
+    }
+
+    get formattedTableLabel() {
+        return (this.tableLabel && this.tableLabel.length > 0) ? '<h2>&nbsp;'+this.tableLabel+'</h2>' : '';
+    }
 
     connectedCallback() {
 
@@ -924,6 +944,10 @@ export default class DatatableV2 extends LightningElement {
         // Update values to be passed back to the Flow
         let selectedRows = event.detail.selectedRows;
         this.updateNumberOfRowsSelected(selectedRows.length);
+        this.setIsInvalidFlag(false);
+        if(this.isRequired && this.numberOfRowsSelected == 0) {
+            this.setIsInvalidFlag(true);
+        }
         let sdata = [];
         selectedRows.forEach(srow => {
             const selData = this.tableData.find(d => d[this.keyField] == srow[this.keyField]);
@@ -1400,4 +1424,25 @@ export default class DatatableV2 extends LightningElement {
         this.columnFilterParameter = (allSelected) ? 'All' : colString.substring(2);
     }
 
+    @api
+    validate() {
+        // Validation logic to pass back to the Flow
+        if(!this.isRequired || this.numberOfRowsSelected > 0) { 
+            this.setIsInvalidFlag(false);
+            return { isValid: true }; 
+        } 
+        else { 
+            // If the component is invalid, return the isValid parameter 
+            // as false and return an error message. 
+            this.setIsInvalidFlag(true);
+            return { 
+                isValid: false, 
+                errorMessage: 'This is a required entry.  At least 1 row must be selected.' 
+            }; 
+        }
+    }
+
+    setIsInvalidFlag(value) {
+        this.isInvalid = value;
+    }
 }

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -1,7 +1,7 @@
 /**
  * Lightning Web Component for Flow Screens:       datatableV2
  * 
- * VERSION:             2.45
+ * VERSION:             2.46
  * 
  * RELEASE NOTES:       https://github.com/ericrsmith35/DatatableV2/blob/master/README.md
  * 
@@ -27,7 +27,7 @@
  *  
  **/
 
- const VERSION_NUMBER = 2.45;
+ const VERSION_NUMBER = 2.46;
 
 import { LightningElement, api, track, wire } from 'lwc';
 import getReturnResults from '@salesforce/apex/SObjectController2.getReturnResults';
@@ -42,7 +42,7 @@ export default class DatatableV2 extends LightningElement {
 
     // Component Input & Output Attributes
     @api tableData = [];
-    @api columnFields;
+    @api columnFields = [];
     @api columnAlignments = [];
     @api columnCellAttribs = [];
     @api columnEdits = '';
@@ -450,7 +450,10 @@ export default class DatatableV2 extends LightningElement {
 
             // Call Apex Controller and get Column Definitions and update Row Data
             let data = (this.tableData) ? JSON.parse(JSON.stringify([...this.tableData])) : [];
-            let fieldList = this.columnFields.replace(/\s/g, ''); // Remove spaces
+console.log('colFields_L',this.columnFields.length);
+// console.log('colFields_V',this.columnFields.replace(/\s/g, ''));
+            let fieldList = (this.columnFields.length > 0) ? this.columnFields.replace(/\s/g, '') : ''; // Remove spaces
+console.log('fieldList','[',fieldList,']');
             getReturnResults({ records: data, fieldNames: fieldList })
             .then(result => {
                 let returnResults = JSON.parse(result);

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -96,6 +96,7 @@ export default class DatatableV2 extends LightningElement {
     @track mydata = [];
     @track selectedRows = [];
     @track roundValueLabel;
+    @track showClearButton = false;
 
     // Handle Lookup Field Variables   
     @api lookupId;
@@ -977,14 +978,14 @@ export default class DatatableV2 extends LightningElement {
     handleRowSelection(event) {
         // Only used with row selection
         // Update values to be passed back to the Flow
-        let selectedRows = event.detail.selectedRows;
-        this.updateNumberOfRowsSelected(selectedRows);
+        let currentSelectedRows = event.detail.selectedRows;
+        this.updateNumberOfRowsSelected(currentSelectedRows);
         this.setIsInvalidFlag(false);
         if(this.isRequired && this.numberOfRowsSelected == 0) {
             this.setIsInvalidFlag(true);
         }
         let sdata = [];
-        selectedRows.forEach(srow => {
+        currentSelectedRows.forEach(srow => {
             const selData = this.tableData.find(d => d[this.keyField] == srow[this.keyField]);
             sdata.push(selData);
         });
@@ -998,13 +999,21 @@ export default class DatatableV2 extends LightningElement {
         console.log('outputSelectedRows',this.outputSelectedRows);
     }
 
-    updateNumberOfRowsSelected(selectedRows) {
+    updateNumberOfRowsSelected(currentSelectedRows) {
         // Handle updating output attribute for the number of selected rows
-        this.numberOfRowsSelected = selectedRows.length;
+        this.numberOfRowsSelected = currentSelectedRows.length;
         this.dispatchEvent(new FlowAttributeChangeEvent('numberOfRowsSelected', this.numberOfRowsSelected));
         // Return an SObject Record if just a single row is selected
-        this.outputSelectedRow = (this.numberOfRowsSelected == 1) ? selectedRows[0] : null;
+        this.outputSelectedRow = (this.numberOfRowsSelected == 1) ? currentSelectedRows[0] : null;
         this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRow', this.outputSelectedRow));
+        this.showClearButton =  (this.tableData.length == 1 && this.numberOfRowsSelected == 1);
+    }
+
+    handleClearSelection() {
+        this.showClearButton = false;
+        this.selectedRows = [];
+        this.outputSelectedRows = this.selectedRows;
+        this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRows', this.outputSelectedRows));
     }
 
     updateColumnSorting(event) {

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -359,7 +359,7 @@ export default class DatatableV2 extends LightningElement {
 
         // Handle pre-selected records
         this.outputSelectedRows = this.preSelectedRows;
-        this.numberOfRowsSelected = this.outputSelectedRows.length;
+        this.updateNumberOfRowsSelected(this.outputSelectedRows.length);
         if (this.isUserDefinedObject) {
             this.outputSelectedRowsString = JSON.stringify(this.outputSelectedRows);                                        //JSON Version
             this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRowsString', this.outputSelectedRowsString));    //JSON Version
@@ -923,7 +923,7 @@ export default class DatatableV2 extends LightningElement {
         // Only used with row selection
         // Update values to be passed back to the Flow
         let selectedRows = event.detail.selectedRows;
-        this.numberOfRowsSelected = selectedRows.length;
+        this.updateNumberOfRowsSelected(selectedRows.length);
         let sdata = [];
         selectedRows.forEach(srow => {
             const selData = this.tableData.find(d => d[this.keyField] == srow[this.keyField]);
@@ -937,6 +937,12 @@ export default class DatatableV2 extends LightningElement {
             this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRows', this.outputSelectedRows));
         }
         console.log('outputSelectedRows',this.outputSelectedRows);
+    }
+
+    updateNumberOfRowsSelected(numberOfRows) {
+        // Handle updating output attribute for the number of selected rows
+        this.numberOfRowsSelected = numberOfRows;
+        this.dispatchEvent(new FlowAttributeChangeEvent('numberOfRowsSelected', this.numberOfRowsSelected));
     }
 
     updateColumnSorting(event) {

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -56,6 +56,7 @@ export default class DatatableV2 extends LightningElement {
     @api matchCaseOnFilters;
     @api maxNumberOfRows;
     @api preSelectedRows = [];
+    @api numberOfRowsSelected = 0;
     @api isConfigMode;
     @api hideCheckboxColumn;
     @api singleRowSelection;
@@ -358,6 +359,7 @@ export default class DatatableV2 extends LightningElement {
 
         // Handle pre-selected records
         this.outputSelectedRows = this.preSelectedRows;
+        this.numberOfRowsSelected = this.outputSelectedRows.length;
         if (this.isUserDefinedObject) {
             this.outputSelectedRowsString = JSON.stringify(this.outputSelectedRows);                                        //JSON Version
             this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRowsString', this.outputSelectedRowsString));    //JSON Version
@@ -452,6 +454,7 @@ export default class DatatableV2 extends LightningElement {
             // Call Apex Controller and get Column Definitions and update Row Data
             let data = (this.tableData) ? JSON.parse(JSON.stringify([...this.tableData])) : [];
             let fieldList = (this.columnFields.length > 0) ? this.columnFields.replace(/\s/g, '') : ''; // Remove spaces
+            console.log('Passing data to Apex Controller', data);
             getReturnResults({ records: data, fieldNames: fieldList })
             .then(result => {
                 let returnResults = JSON.parse(result);
@@ -920,6 +923,7 @@ export default class DatatableV2 extends LightningElement {
         // Only used with row selection
         // Update values to be passed back to the Flow
         let selectedRows = event.detail.selectedRows;
+        this.numberOfRowsSelected = selectedRows.length;
         let sdata = [];
         selectedRows.forEach(srow => {
             const selData = this.tableData.find(d => d[this.keyField] == srow[this.keyField]);

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js-meta.xml
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js-meta.xml
@@ -16,8 +16,10 @@
             <property name="preSelectedRows" label="Pre-Selected Rows" type="{T[]}" role="inputOnly" description="Record Collection variable containing the records to show as pre-selected in the datatable."/>
             <property name="outputEditedRows" label="Output Edited Rows" type="{T[]}" role="outputOnly" description="Record Collection variable to contain only the records that were edited in the datatable. 
                 - NOTE: To write these edits back to the Object, you will need to do a Record Update in the Flow."/>
-            <property name="outputSelectedRows" label="Output Selected Rows" type="{T[]}" role="outputOnly" description="Record Collection variable to contain only the records that were selected in the datatable. 
+            <property name="outputSelectedRows" label="Output Selected Rows (Collection)" type="{T[]}" role="outputOnly" description="Record Collection variable to contain only the records that were selected in the datatable. 
                 - NOTE: These records may not contain all of the edited values."/>
+            <property name="outputSelectedRow" label="Output Selected Row (Object)" type="{T}" role="outputOnly" description="Record Object variable that contains the single record that was selected in the datatable. 
+                - NOTE: This is only provided when just a single record is selected."/>
   
             <!-- ============== These parameters are used when providing a User Defined object rather than a Salesforce SObject ============== -->  
             

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js-meta.xml
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js-meta.xml
@@ -61,6 +61,7 @@
             <property name="keyField" label="Key Field" type="String" default="Id" role="inputOnly" description="This is normally the Id field, but you can specify a different field if all field values are unique."/>
             <property name="matchCaseOnFilters" label="Match Case on Column Filters?" type="Boolean" default="false" role="inputOnly" description="Set to True is you want to force an exact match on case for column filter values."/>
             <property name="maxNumberOfRows" label="Maximum Number of Records to Display" type="Integer" role="inputOnly" description="Enter a number here if you want to restrict how many rows will be displayed in the datatable."/>
+            <property name="isRequired" label="Required?" type="Boolean" default="false" role="inputOnly" description="Require at least 1 row to be selected?"/>
             <property name="singleRowSelection" label="Single Row Selection (Radio Buttons)?" type="Boolean" default="false" role="inputOnly" description="When set to True, Radio Buttons will be displayed and only a single row can be selected.  
                 The default (False) will display Checkboxes and allow multiple records to be selected."/>
             <property name="suppressBottomBar" label="Suppress Cancel/Save Buttons during Edit Mode?" type="Boolean" default="false" role="inputOnly" description="Cancel/Save buttons will appear by default at the very bottom of the table once a field is edited.  
@@ -68,6 +69,8 @@
             <property name="suppressNameFieldLink" label="Suppress the Link on the Object's 'Name' Field" type="Boolean" default="false" role="inputOnly" description="Suppress the default behavior of displaying the SObject's 'Name' field as a link to the record"/>
             <property name="tableHeight" label="Table Height" type="String" role="inputOnly" description="CSS specification for the height of the datatable (Examples: 30rem, calc(50vh - 100px)  If you leave this blank, the datatable will expand to display all records.)"/>
             <property name="tableBorder" label="Table Border" type="Boolean" default="true" role="inputOnly" description="Display a border around the datatable."/>
+            <property name="tableIcon" label="Table Icon" type="String" role="inputOnly" description="(Optional) Icon to display on the Table Header. Example: standard:account"/>
+            <property name="tableLabel" label="Table Label" type="String" role="inputOnly" description="(Optional) Label to display on the Table Header"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/datatableV2/datatableV2.js-meta.xml
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js-meta.xml
@@ -29,6 +29,9 @@
             <property name="outputEditedRowsString" label="Output Edited Rows (User Defined)" type="String" role="outputOnly" description="Object Collection string variable to contain only the records that were edited in the datatable."/>
   
             <!-- ============================================================================================================================- -->  
+            
+            <!-- Additional Output Parameters -->
+            <property name="numberOfRowsSelected" label="Output Number of Selected Records" type="Integer" role="outputOnly" description="Total count of the number of selected records"/>
   
             <!-- Forcing sort order of parameters with special characters _(1) -(2) .(3) -->  
             <property name="columnFields" label="_ Column Fields" type="String" role="inputOnly" description="REQUIRED: Comma separated list of field API Names to display in the datatable."/>


### PR DESCRIPTION
10/07/20 -  Eric Smith -    Version 2.46 -  
            Updates:        Added new Output Parameter for the # of Selected Records 
                            (this can be used for conditional visibility on the same screen as the datatable)   
                            New Selected Record Output Parameter - Returns an SObject record if just a single record is selected 
                            New Required? Parameter - Requires the user to select at least 1 row to proceed  
                            New optional Table Header with Table Icon and Table Label Parameters  
                            Switched DualListbox to the fbc version  
                            Added spinners while sorting & filtering data  
                            Allow case insensitive field API names  
                            Allow custom field API names w/o the __c suffix  
            Bug Fixes:      Display Picklist Labels instead of API Names for Picklist and Multipicklist fields  
                            Added a Clear Selection button for tables with just a single record