### PR TITLE
allow clear selection for multi-row tables 

### DIFF
--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -1006,13 +1006,14 @@ export default class DatatableV2 extends LightningElement {
         // Return an SObject Record if just a single row is selected
         this.outputSelectedRow = (this.numberOfRowsSelected == 1) ? currentSelectedRows[0] : null;
         this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRow', this.outputSelectedRow));
-        this.showClearButton =  (this.tableData.length == 1 && this.numberOfRowsSelected == 1);
+        this.showClearButton = this.numberOfRowsSelected > 0;
     }
 
     handleClearSelection() {
         this.showClearButton = false;
         this.selectedRows = [];
         this.outputSelectedRows = this.selectedRows;
+        this.numberOfRowsSelected = 0;
         this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRows', this.outputSelectedRows));
     }
 


### PR DESCRIPTION
Hi Eric, while using the datatableV2 I noticed that the clear selection was being shown only when the table has one entry.  Further, if the "clear selection" button was pressed, the state variable `numberOfRowsSelected` was not being updated which caused some routing errors in a flow I was creating. The changes in the PR would allow for the clear selection button to appear on multi row tables, and will set the `numberOfRowsSelected` variable back to zero when it is clicked. Feel free to reach out with any questions/concerns. 