### PR TITLE
don't show radio button when tableData.length is 1

### DIFF
--- a/force-app/main/default/lwc/datatableV2/datatableV2.js
+++ b/force-app/main/default/lwc/datatableV2/datatableV2.js
@@ -374,7 +374,7 @@ export default class DatatableV2 extends LightningElement {
         if (this.tableData) {
 
             // Set other initial values here
-            this.maxRowSelection = (this.singleRowSelection) ? 1 : this.tableData.length;
+            this.maxRowSelection = (this.singleRowSelection) ? 1 : Number.MAX_SAFE_INTEGER;
 
             console.log('Processing Datatable');
             this.processDatatable();


### PR DESCRIPTION
When the table only contains a single row (tableData.length === 1), maxRowSelection is set to 1 and the row checkbox becomes a radio button, which cannot be deselected by the user.

This should not happen and radio buttons should only replace checkboxes when the option "Single Row Selection (Radio Buttons)?" (singleRowSelection) is activated explicitly.